### PR TITLE
Add support for Serializer.can_include(:model)

### DIFF
--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -29,6 +29,13 @@ ActiveRecord::Schema.define(:version => 1) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "payments", :force => true do |t|
+    t.integer "amount"
+    t.integer  "artist_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 end
 
 class Artist < ActiveRecord::Base
@@ -36,6 +43,7 @@ class Artist < ActiveRecord::Base
 
   has_many :albums
   has_many :songs
+  has_many :payments
 end
 
 class Album < ActiveRecord::Base
@@ -50,4 +58,10 @@ class Song < ActiveRecord::Base
 
   belongs_to :artist
   belongs_to :album
+end
+
+class Payment < ActiveRecord::Base
+  attr_accessible :amount, :artist
+
+  belongs_to :artist
 end

--- a/spec/fixtures/serializers.rb
+++ b/spec/fixtures/serializers.rb
@@ -1,14 +1,17 @@
 class SongSerializer
   include RestPack::Serializer
   attributes :id, :title, :album_id
+  can_include :albums, :artists
 end
 
 class AlbumSerializer
   include RestPack::Serializer
   attributes :id, :title, :year, :artist_id
+  can_include :artists, :songs
 end
 
 class ArtistSerializer
   include RestPack::Serializer
   attributes :id, :name, :website
+  can_include :albums, :songs
 end

--- a/spec/serializable/side_loading/side_loading_spec.rb
+++ b/spec/serializable/side_loading/side_loading_spec.rb
@@ -6,13 +6,46 @@ describe RestPack::Serializer::SideLoading do
       FactoryGirl.create(:song)
     end
 
-    it "raises an exception" do
-      exception = RestPack::Serializer::InvalidInclude
-      message = ":wrong is not a valid include for Song"
+    context "an include to an inexistent model" do
+      it "raises an exception" do
+        exception = RestPack::Serializer::InvalidInclude
+        message = ":wrong is not a valid include for Song"
 
-      expect do
-        SongSerializer.side_loads([Song.first], RestPack::Serializer::Options.new(Song, { "includes" => "wrong" }))
-      end.to raise_error(exception, message)
+        expect do
+          SongSerializer.side_loads([Song.first], RestPack::Serializer::Options.new(Song, { "includes" => "wrong" }))
+        end.to raise_error(exception, message)
+      end
+    end
+
+    context "an include to a model which has not been whitelisted with 'can_include'" do
+      it "raises an exception" do
+        payment = FactoryGirl.create(:payment)
+        exception = RestPack::Serializer::InvalidInclude
+        message = ":payments is not a valid include for Artist"
+
+        expect do
+          ArtistSerializer.side_loads([payment.artist], RestPack::Serializer::Options.new(Artist, { "includes" => "payments" }))
+        end.to raise_error(exception, message)
+      end
+    end
+  end
+
+  describe "#can_include" do
+    class CustomSerializer
+      include RestPack::Serializer
+      attributes :a, :b, :c
+    end
+    it "defaults to empty array" do
+      CustomSerializer.can_includes.should == []
+    end
+
+    it "allows includes to be specified" do
+      class CustomSerializer
+        can_include :model1
+        can_include :model2, :model3
+      end
+
+      CustomSerializer.can_includes.should == [:model1, :model2, :model3]
     end
   end
 

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -37,4 +37,9 @@ FactoryGirl.define do
     artist
     album
   end
+
+  factory :payment do
+    amount 999
+    artist
+  end
 end


### PR DESCRIPTION
As per https://github.com/RestPack/restpack-serializer/issues/4, this allows a whitelist of valid includes to be defined in a Serializer:

``` ruby
class AlbumSerializer
  include RestPack::Serializer
  attributes :id, :title, :year, :artist_id

  can_include :artist, :songs 
end
```
