### PR TITLE
RestPack::Serializer.config.page_size is now configurable

### DIFF
--- a/lib/restpack_serializer.rb
+++ b/lib/restpack_serializer.rb
@@ -2,13 +2,17 @@ require 'will_paginate'
 require 'will_paginate/active_record'
 
 require 'restpack_serializer/version'
+require 'restpack_serializer/configuration'
 require 'restpack_serializer/serializable'
 require 'restpack_serializer/factory'
 
 module RestPack
   module Serializer
-    mattr_accessor :href_prefix
+    mattr_accessor :config
+    @@config = Configuration.new
 
-    @@href_prefix = ''
+    def self.setup
+      yield @@config
+    end
   end
 end

--- a/lib/restpack_serializer/configuration.rb
+++ b/lib/restpack_serializer/configuration.rb
@@ -1,0 +1,12 @@
+module RestPack
+  module Serializer
+    class Configuration
+      attr_accessor :href_prefix, :page_size
+
+      def initialize
+        @href_prefix = ''
+        @page_size = 10
+      end
+    end
+  end
+end

--- a/lib/restpack_serializer/options.rb
+++ b/lib/restpack_serializer/options.rb
@@ -2,13 +2,11 @@ module RestPack::Serializer
   class Options
     attr_accessor :page, :page_size, :includes, :filters, :model_class, :scope, :include_links
 
-    DEFAULT_PAGE_SIZE = 10
-
     def initialize(model_class, params = {}, scope = nil)
       params.symbolize_keys! if params.respond_to?(:symbolize_keys!)
 
       @page = 1
-      @page_size = DEFAULT_PAGE_SIZE
+      @page_size = RestPack::Serializer.config.page_size
       @includes = []
       @filters = filters_from_params(params, model_class)
       @model_class = model_class
@@ -34,7 +32,7 @@ module RestPack::Serializer
     end
 
     def default_page_size?
-      @page_size == DEFAULT_PAGE_SIZE
+      @page_size == RestPack::Serializer.config.page_size
     end
 
     def filters_as_url_params

--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -2,7 +2,7 @@ module RestPack::Serializer::Attributes
   extend ActiveSupport::Concern
 
   def default_href
-    "#{RestPack::Serializer.href_prefix}/#{@model.class.table_name}/#{@model.id}.json"
+    "#{RestPack::Serializer.config.href_prefix}/#{@model.class.table_name}/#{@model.id}.json"
   end
 
   module ClassMethods

--- a/lib/restpack_serializer/serializable/paging.rb
+++ b/lib/restpack_serializer/serializable/paging.rb
@@ -57,7 +57,7 @@ module RestPack::Serializer::Paging
     def page_href(page, options)
       return nil unless page
 
-      url = "#{RestPack::Serializer.href_prefix}/#{self.key}.json"
+      url = "#{RestPack::Serializer.config.href_prefix}/#{self.key}.json"
 
       params = []
       params << "page=#{page}" unless page == 1

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -45,7 +45,7 @@ module RestPack::Serializer::SideLoading
         end
 
         links[link_key] = {
-          :href => RestPack::Serializer.href_prefix + href,
+          :href => RestPack::Serializer.config.href_prefix + href,
           :type => association.plural_name.to_sym
         }
       end

--- a/spec/restpack_serializer_spec.rb
+++ b/spec/restpack_serializer_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe RestPack::Serializer do
+  before { @original_config = subject.config.clone }
+  after { subject.config = @original_config }
+
+  context "#setup" do
+    it "has defaults" do
+      subject.config.href_prefix.should == ''
+      subject.config.page_size.should == 10
+    end
+
+    it "can be configured" do
+      subject.setup do |config|
+        config.href_prefix = '/api/v1'
+        config.page_size = 50
+      end
+
+      subject.config.href_prefix.should == '/api/v1'
+      subject.config.page_size.should == 50
+    end
+  end
+end

--- a/spec/serializable/side_loading/side_loading_spec.rb
+++ b/spec/serializable/side_loading/side_loading_spec.rb
@@ -61,11 +61,11 @@ describe RestPack::Serializer::SideLoading do
       }
     }
 
-    it "applies custom RestPack::Serializer.href_prefix" do
-      original = RestPack::Serializer.href_prefix
-      RestPack::Serializer.href_prefix = "/api/v1"
+    it "applies custom RestPack::Serializer.config.href_prefix" do
+      original = RestPack::Serializer.config.href_prefix
+      RestPack::Serializer.config.href_prefix = "/api/v1"
       AlbumSerializer.links["albums.artist"][:href].should == "/api/v1/artists/{albums.artist}.json"
-      RestPack::Serializer.href_prefix = original
+      RestPack::Serializer.config.href_prefix = original
     end
   end
 


### PR DESCRIPTION
Like this:

``` ruby
RestPack::Serializer.setup do |config|
  config.href_prefix = '/api/v1'
  config.page_size = 50
end
```
