### PR TITLE
Move side-loaded resources to :linked hash

### DIFF
--- a/lib/restpack_serializer.rb
+++ b/lib/restpack_serializer.rb
@@ -5,6 +5,7 @@ require 'restpack_serializer/version'
 require 'restpack_serializer/configuration'
 require 'restpack_serializer/serializable'
 require 'restpack_serializer/factory'
+require 'restpack_serializer/result'
 
 module RestPack
   module Serializer

--- a/lib/restpack_serializer/result.rb
+++ b/lib/restpack_serializer/result.rb
@@ -1,0 +1,53 @@
+module RestPack::Serializer
+  class Result
+    attr_accessor :resources, :meta, :links
+
+    def initialize
+      @resources = {}
+      @meta = {}
+      @links = {}
+    end
+
+    def serialize
+      result = {}
+
+      result[:meta] = @meta unless @meta.empty?
+      result[:links] = @links unless @links.empty?
+
+      unless @resources.empty?
+        inject_to_many_links!
+        result[@resources.keys.first] = @resources.values.first
+
+        linked = @resources.except(@resources.keys.first)
+        result[:linked] = linked unless linked.empty?
+      end
+
+      result
+    end
+
+    private
+
+    def inject_to_many_links! #find and inject to_many links from related @resources
+      @resources.keys.each do |key|
+        @resources[key].each do |item|
+          if item[:links]
+            item[:links].each do |link_key, link_value|
+              unless link_value.is_a? Array
+                plural_linked_key = "#{link_key}s".to_sym
+
+                if @resources[plural_linked_key]
+                  linked_resource = @resources[plural_linked_key].find { |i| i[:id] == link_value }
+                  if linked_resource
+                    linked_resource[:links] ||= {}
+                    linked_resource[:links][key] ||= []
+                    linked_resource[:links][key] << item[:id]
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe RestPack::Serializer::Result do
+  context 'a new instance' do
+    it 'has defaults' do
+      subject.resources.should == {}
+      subject.meta.should == {}
+      subject.links.should == {}
+    end
+  end
+
+  context 'when serializing' do
+    let(:result) { subject.serialize }
+    context 'in jsonapi.org format' do
+      context 'an empty result' do
+        it 'returns an empty result' do
+          result.should == {}
+        end
+      end
+
+      context 'a simple list of resources' do
+        before do
+          subject.resources[:albums] = [{ name: 'Album 1' }, { name: 'Album 2'}]
+          subject.meta[:albums] = { count: 2 }
+          subject.links['albums.songs'] = { href: 'songs.json', type: 'songs' }
+        end
+
+        it 'returns correct jsonapi.org format' do
+          result[:albums].should == subject.resources[:albums]
+          result[:meta].should == subject.meta
+          result[:links].should == subject.links
+        end
+      end
+
+      context 'a list with side-loaded resources' do
+        before do
+          subject.resources[:albums] = [{ id: '1', name: 'AMOK'}]
+          subject.resources[:songs] = [{ id: '91', name: 'Before Your Very Eyes...', links: { album: '1' }}]
+          subject.links['albums.songs'] = { type: 'songs', href: '/api/v1/songs?album_id={albums.id}' }
+          subject.links['songs.album'] = { type: 'albums', href: '/api/v1/albums/{songs.album}' }
+        end
+
+        it 'returns correct jsonapi.org format, including injected to_many links' do
+          result[:albums].should == [{ id: '1', name: 'AMOK', links: { songs: ['91'] } }]
+          result[:links].should == subject.links
+          result[:linked][:songs].should == subject.resources[:songs]
+        end
+      end
+    end
+  end
+end

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -101,7 +101,7 @@ describe RestPack::Serializer::Paging do
       let(:params) { { include: 'albums' } }
 
       it "includes side-loaded models" do
-        page[:albums].should_not == nil
+        page[:linked][:albums].should_not == nil
       end
 
       it "includes the side-loads in the main meta data" do
@@ -118,7 +118,7 @@ describe RestPack::Serializer::Paging do
         song[:links][:album].should == song_model.album_id.to_s
         song[:links][:artist].should == song_model.artist_id.to_s
 
-        album = page[:albums].first
+        album = page[:linked][:albums].first
         album_model = MyApp::Album.find(album[:id])
 
         album[:links][:artist].should == album_model.artist_id.to_s
@@ -128,8 +128,8 @@ describe RestPack::Serializer::Paging do
       context "with includes as comma delimited string" do
         let(:params) { { include: "albums,artists" } }
         it "includes side-loaded models" do
-          page[:albums].should_not == nil
-          page[:artists].should_not == nil
+          page[:linked][:albums].should_not == nil
+          page[:linked][:artists].should_not == nil
         end
 
         it "includes the side-loads in page hrefs" do

--- a/spec/serializable/resource_spec.rb
+++ b/spec/serializable/resource_spec.rb
@@ -18,8 +18,8 @@ describe RestPack::Serializer::Resource do
     let(:params) { { id: @song.id, include: 'albums' } }
 
     it "includes side-loaded models" do
-      resource[:albums].count.should == 1
-      resource[:albums].first[:id].should == @song.album.id.to_s
+      resource[:linked][:albums].count.should == 1
+      resource[:linked][:albums].first[:id].should == @song.album.id.to_s
     end
 
     it "includes the side-loads in the main meta data" do

--- a/spec/serializable/side_loading/side_loading_spec.rb
+++ b/spec/serializable/side_loading/side_loading_spec.rb
@@ -75,7 +75,7 @@ describe RestPack::Serializer::SideLoading do
         MyApp::ArtistSerializer.filterable_by.should == [:id]
       end
     end
-    context "a model with a single :belongs_torelations" do
+    context "a model with a single :belongs_to relations" do
       it "is filterable by primary key and foreign keys" do
         MyApp::AlbumSerializer.filterable_by.should =~ [:id, :artist_id, :year]
       end


### PR DESCRIPTION
This PR includes a new `result` class which will make it easier to add future support for serialization formats other than jsonapi.org. I also moved side-loaded resources into a `:linked` hash to comply with a recent jsonapi.org standard change
