### PR TITLE
added #single method to Serializer

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -4,6 +4,7 @@ require_relative "serializable/attributes"
 require_relative "serializable/filterable"
 require_relative "serializable/paging"
 require_relative "serializable/resource"
+require_relative "serializable/single"
 require_relative "serializable/side_loading"
 
 module RestPack
@@ -20,6 +21,7 @@ module RestPack
 
     include RestPack::Serializer::Paging
     include RestPack::Serializer::Resource
+    include RestPack::Serializer::Single
     include RestPack::Serializer::Attributes
     include RestPack::Serializer::Filterable
     include RestPack::Serializer::SideLoading

--- a/lib/restpack_serializer/serializable/single.rb
+++ b/lib/restpack_serializer/serializable/single.rb
@@ -1,0 +1,12 @@
+module RestPack::Serializer::Single
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def single(params = {}, scope = nil, context = {})
+      options = RestPack::Serializer::Options.new(self, params, scope, context)
+      model = options.scope_with_filters.first
+
+      return model ? self.as_json(model, context) : nil
+    end
+  end
+end

--- a/spec/serializable/single_spec.rb
+++ b/spec/serializable/single_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe RestPack::Serializer::Single do
+  before(:each) do
+    @album = FactoryGirl.create(:album_with_songs, song_count: 11)
+    @song = @album.songs.first
+  end
+
+  let(:resource) { MyApp::SongSerializer.single(params, scope, context) }
+  let(:params) { { id: @song.id } }
+  let(:scope) { nil }
+  let(:context) { { } }
+
+  it "returns a resource by id" do
+    resource[:id].should == @song.id.to_s
+    resource[:title].should == @song.title
+  end
+
+  context "with context" do
+    let(:context) { { reverse_title?: true } }
+
+    it "returns reversed titles" do
+      resource[:title].should == @song.title.reverse
+    end
+  end
+
+  context "invalid id" do
+    let(:params) { { id: @song.id + 100 } }
+
+    it "returns nil" do
+      resource.should == nil
+    end
+  end
+end


### PR DESCRIPTION
Similarly to Serializer.resource(params), this will find and serialize a single resource but it will exclude paging info and other meta data. It will result in a single DB query.

https://github.com/RestPack/restpack_serializer/issues/53
