### PR TITLE
Use model.to_param instead of model.id for URLs

### DIFF
--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -2,7 +2,7 @@ module RestPack::Serializer::Attributes
   extend ActiveSupport::Concern
 
   def default_href
-    "#{RestPack::Serializer.config.href_prefix}/#{self.class.key}/#{@model.id}"
+    "#{RestPack::Serializer.config.href_prefix}/#{self.class.key}/#{@model.to_param}"
   end
 
   module ClassMethods

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -15,6 +15,10 @@ describe RestPack::Serializer do
     def self.table_name
       "people"
     end
+
+    def to_param
+      id.to_s
+    end
   end
 
   context "bare bones serializer" do


### PR DESCRIPTION
Rails uses the #to_param method on model objects in its url helpers, so
identifiers other than the database's primary key can easily be used to
identify a resource in a url. Since, as far as I am aware, JSON API
doesn't have any specific requirements for what an id has to be,
this allows users to use customize their URLs in the same manner as they
would in a Rails view.
