### PR TITLE
recursively symbolizing :as_json output

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -6,6 +6,7 @@ require_relative "serializable/paging"
 require_relative "serializable/resource"
 require_relative "serializable/single"
 require_relative "serializable/side_loading"
+require_relative "serializable/symbolizer"
 
 module RestPack
   module Serializer
@@ -46,7 +47,7 @@ module RestPack
       add_custom_attributes(data)
       add_links(model, data)
 
-      data
+      Symbolizer.recursive_symbolize(data)
     end
 
     def custom_attributes

--- a/lib/restpack_serializer/serializable/symbolizer.rb
+++ b/lib/restpack_serializer/serializable/symbolizer.rb
@@ -1,0 +1,20 @@
+class Symbolizer
+  def self.recursive_symbolize(hash)
+    {}.tap do |h|
+      hash.each { |key, value| h[key.to_sym] = self.map_value(value) }
+    end
+  end
+
+  private
+
+  def self.map_value(thing)
+    case thing
+    when Hash
+      self.recursive_symbolize(thing)
+    when Array
+      thing.map { |v| map_value(v) }
+    else
+      thing
+    end
+  end
+end

--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
   gem.add_development_dependency 'rake', '~> 10.0.3'
-  gem.add_development_dependency 'rspec', '~> 2.12'
   gem.add_development_dependency 'guard-rspec', '~> 2.5.4'
   gem.add_development_dependency 'growl', '~> 1.0.3'
   gem.add_development_dependency 'factory_girl', '~> 4.2.0'

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -36,7 +36,12 @@ describe RestPack::Serializer do
     end
 
     def admin_info
-      { key: "super_secret_sauce" }
+      {
+        "key" => "super_secret_sauce",
+        "array" => [
+          { "name" => "Alex" }
+        ]
+      }
     end
 
     def include_admin_info?
@@ -120,7 +125,12 @@ describe RestPack::Serializer do
 
       it "includes custom attributes if specified" do
         hash = serializer.as_json(person, { is_admin?: true })
-        hash[:admin_info].should == { key: "super_secret_sauce" }
+        hash[:admin_info].should == {
+          key: "super_secret_sauce",
+          array: [
+            name: 'Alex'
+          ]
+        }
       end
     end
 


### PR DESCRIPTION
/cc @ocfnash All output from our serializers will now use a symbolized format
