### PR TITLE
Add the ability to sort results

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,23 @@ Side-loading is available when filtering:
 
  * http://restpack-serializer-sample.herokuapp.com/api/v1/albums.json?artist_ids=2,3&include=artists,songs
 
+## Sorting
+
+Sorting attributes can be defined with the `can_sort_by` option:
+
+ ```ruby
+class Account
+    include RestPack::Serializer
+    attributes :id, :application_id, :created_by, :name, :href
+
+    can_sort_by :id, :name
+end
+```
+
+ * http://restpack-serializer-sample.herokuapp.com/api/v1/albums.json?sort=id
+ * http://restpack-serializer-sample.herokuapp.com/api/v1/albums.json?sort=-name
+ * http://restpack-serializer-sample.herokuapp.com/api/v1/albums.json?sort=name,-id
+
 ## Running Tests
 
 `bundle`

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -7,6 +7,7 @@ require_relative "serializable/resource"
 require_relative "serializable/single"
 require_relative "serializable/side_loading"
 require_relative "serializable/symbolizer"
+require_relative "serializable/sortable"
 
 module RestPack
   module Serializer
@@ -26,6 +27,7 @@ module RestPack
     include RestPack::Serializer::Attributes
     include RestPack::Serializer::Filterable
     include RestPack::Serializer::SideLoading
+    include RestPack::Serializer::Sortable
 
     class InvalidInclude < Exception; end
 

--- a/lib/restpack_serializer/serializable/paging.rb
+++ b/lib/restpack_serializer/serializable/paging.rb
@@ -8,6 +8,7 @@ module RestPack::Serializer::Paging
 
     def page_with_options(options)
       page = options.scope_with_filters.page(options.page).per(options.page_size)
+      page = page.reorder(options.sorting) if options.sorting.any?
 
       result = RestPack::Serializer::Result.new
       result.resources[self.key] = serialize_page(page, options)
@@ -58,6 +59,7 @@ module RestPack::Serializer::Paging
       params << "page=#{page}" unless page == 1
       params << "page_size=#{options.page_size}" unless options.default_page_size?
       params << "include=#{options.include.join(',')}" if options.include.any?
+      params << options.sorting_as_url_params if options.sorting.any?
       params << options.filters_as_url_params if options.filters.any?
 
       url += '?' + params.join('&') if params.any?

--- a/lib/restpack_serializer/serializable/sortable.rb
+++ b/lib/restpack_serializer/serializable/sortable.rb
@@ -1,0 +1,14 @@
+module RestPack::Serializer::Sortable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_reader :serializable_sorting_attributes
+
+    def can_sort_by(*attributes)
+      @serializable_sorting_attributes = []
+      attributes.each do |attribute|
+        @serializable_sorting_attributes << attribute.to_sym
+      end
+    end
+  end
+end

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -57,6 +57,8 @@ module MyApp
   end
 
   class Song < ActiveRecord::Base
+    default_scope -> { order(id: :asc) }
+
     attr_accessible :title, :artist, :album
 
     belongs_to :artist

--- a/spec/fixtures/serializers.rb
+++ b/spec/fixtures/serializers.rb
@@ -4,6 +4,7 @@ module MyApp
     attributes :id, :title, :album_id
     can_include :albums, :artists
     can_filter_by :title
+    can_sort_by :id, :title
 
     def title
       @context[:reverse_title?] ? @model.title.reverse : @model.title

--- a/spec/serializable/options_spec.rb
+++ b/spec/serializable/options_spec.rb
@@ -59,6 +59,33 @@ describe RestPack::Serializer::Options do
     end
   end
 
+  context 'with sorting parameters' do
+    describe 'with no params' do
+      let(:params) { { } }
+      it { subject.sorting.should == {} }
+    end
+    describe 'with a sorting value' do
+      let(:params) { { 'sort' => 'Title' } }
+      it { subject.sorting.should == { title: :asc } }
+      it { subject.sorting_as_url_params.should == 'sort=title' }
+    end
+    describe 'with a descending sorting value' do
+      let(:params) { { 'sort' => '-title' } }
+      it { subject.sorting.should == { title: :desc } }
+      it { subject.sorting_as_url_params.should == 'sort=-title' }
+    end
+    describe 'with multiple sorting values' do
+      let(:params) { { 'sort' => '-Title,ID' } }
+      it { subject.sorting.should == { title: :desc, id: :asc } }
+      it { subject.sorting_as_url_params.should == 'sort=-title,id' }
+    end
+    describe 'with a not allowed sorting value' do
+      let(:params) { { 'sort' => '-title,album_id,id' } }
+      it { subject.sorting.should == { title: :desc, id: :asc } }
+      it { subject.sorting_as_url_params.should == 'sort=-title,id' }
+    end
+  end
+
   context 'scopes' do
     describe 'with default scope' do
       it { subject.scope.should == MyApp::Song.all }

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -180,6 +180,28 @@ describe RestPack::Serializer::Paging do
       end
     end
 
+    context 'when sorting' do
+      context 'with no sorting' do
+        let(:params) { {} }
+
+        it "uses the model's sorting" do
+          page[:songs].first[:id].to_i.should < page[:songs].last[:id].to_i
+        end
+      end
+
+      context 'with descending title sorting' do
+        let(:params) { { sort: '-title' } }
+
+        it 'returns a page with sorted songs' do
+          page[:songs].first[:title].should > page[:songs].last[:title]
+        end
+
+        it 'includes the sorting in page hrefs' do
+          page[:meta][:songs][:next_href].should == '/songs?page=2&sort=-title'
+        end
+      end
+    end
+
     context "with custom scope" do
       before do
         FactoryGirl.create(:album, year: 1930)

--- a/spec/serializable/sortable_spec.rb
+++ b/spec/serializable/sortable_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe RestPack::Serializer::Sortable do
+  class CustomSerializer
+    include RestPack::Serializer
+    attributes :a, :b, :c
+
+    can_sort_by :a, :c
+  end
+
+  it 'captures the specified sorting attributes' do
+    CustomSerializer.serializable_sorting_attributes.should == [:a, :c]
+  end
+end


### PR DESCRIPTION
I've added a basic sorting (based on the [jsonapi spec](http://jsonapi.org/format/#fetching-sorting)).

For now it only supports sort (not sort[DOCUMENT_TYPE])

I also haven't added any default (eg. on the primary key), because I think it should be opt-in by the user/developer if she want to have records sorted on it or not. What do you think?
