### PR TITLE
Added multi word compatibility for model and serializers

### DIFF
--- a/lib/restpack_serializer/factory.rb
+++ b/lib/restpack_serializer/factory.rb
@@ -7,7 +7,7 @@ class RestPack::Serializer::Factory
   private
 
   def self.classify(identifier)
-    normalised_identifier = identifier.to_s.downcase
+    normalised_identifier = identifier.to_s.underscore
     [normalised_identifier, normalised_identifier.singularize].each do |format|
       klass = RestPack::Serializer.class_map[format]
       return klass.new if klass

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -14,9 +14,9 @@ module RestPack
     @@class_map ||= {}
 
     included do
-      identifier = self.to_s.downcase.chomp('serializer')
+      identifier = self.to_s.underscore.chomp('_serializer')
       @@class_map[identifier] = self
-      @@class_map[identifier.split('::').last] = self
+      @@class_map[identifier.split('/').last] = self
     end
 
     include RestPack::Serializer::Paging

--- a/spec/factory/factory_spec.rb
+++ b/spec/factory/factory_spec.rb
@@ -3,26 +3,47 @@ require 'spec_helper'
 describe RestPack::Serializer::Factory do
   let(:factory) { RestPack::Serializer::Factory }
 
-  it "creates by string" do
-    factory.create("Song").should be_an_instance_of(MyApp::SongSerializer)
-  end
-  it "creates by lowercase string" do
-    factory.create("song").should be_an_instance_of(MyApp::SongSerializer)
-  end
-  it "creates by lowercase plural string" do
-    factory.create("songs").should be_an_instance_of(MyApp::SongSerializer)
-  end
-  it "creates by symbol" do
-    factory.create(:song).should be_an_instance_of(MyApp::SongSerializer)
-  end
-  it "creates by class" do
-    factory.create(MyApp::Song).should be_an_instance_of(MyApp::SongSerializer)
+  describe "single-word" do
+    it "creates by string" do
+      factory.create("Song").should be_an_instance_of(MyApp::SongSerializer)
+    end
+    it "creates by lowercase string" do
+      factory.create("song").should be_an_instance_of(MyApp::SongSerializer)
+    end
+    it "creates by lowercase plural string" do
+      factory.create("songs").should be_an_instance_of(MyApp::SongSerializer)
+    end
+    it "creates by symbol" do
+      factory.create(:song).should be_an_instance_of(MyApp::SongSerializer)
+    end
+    it "creates by class" do
+      factory.create(MyApp::Song).should be_an_instance_of(MyApp::SongSerializer)
+    end
+
+    it "creates multiple with Array" do
+      serializers = factory.create("Song", "artists", :album)
+      serializers[0].should be_an_instance_of(MyApp::SongSerializer)
+      serializers[1].should be_an_instance_of(MyApp::ArtistSerializer)
+      serializers[2].should be_an_instance_of(MyApp::AlbumSerializer)
+    end
   end
 
-  it "creates multiple with Array" do
-    serializers = factory.create("Song", "artists", :album)
-    serializers[0].should be_an_instance_of(MyApp::SongSerializer)
-    serializers[1].should be_an_instance_of(MyApp::ArtistSerializer)
-    serializers[2].should be_an_instance_of(MyApp::AlbumSerializer)
+  describe "multi-word" do
+    it "creates multi-word string" do
+      factory.create("AlbumReview").should be_an_instance_of(MyApp::AlbumReviewSerializer)
+    end
+    it "creates multi-word lowercase string" do
+      factory.create("album_review").should be_an_instance_of(MyApp::AlbumReviewSerializer)
+    end
+    it "creates multi-word lowercase plural string" do
+      factory.create("album_reviews").should be_an_instance_of(MyApp::AlbumReviewSerializer)
+    end
+    it "creates multi-word symbol" do
+      factory.create(:album_review).should be_an_instance_of(MyApp::AlbumReviewSerializer)
+    end
+    it "creates multi-word class" do
+      factory.create(MyApp::AlbumReview).should be_an_instance_of(MyApp::AlbumReviewSerializer)
+    end
   end
+
 end

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -23,6 +23,13 @@ ActiveRecord::Schema.define(:version => 1) do
     t.datetime "updated_at"
   end
 
+  create_table "album_reviews", :force => true do |t|
+    t.string   "message"
+    t.integer  "album_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "songs", :force => true do |t|
     t.string   "title"
     t.integer  "album_id"
@@ -54,6 +61,12 @@ module MyApp
 
     belongs_to :artist
     has_many :songs
+    has_many :album_reviews
+  end
+
+  class AlbumReview < ActiveRecord::Base
+    attr_accessible :message
+    belongs_to :album
   end
 
   class Song < ActiveRecord::Base

--- a/spec/fixtures/serializers.rb
+++ b/spec/fixtures/serializers.rb
@@ -17,6 +17,12 @@ module MyApp
     can_filter_by :year
   end
 
+  class AlbumReviewSerializer
+    include RestPack::Serializer
+    attributes :message
+    can_filter_by :album
+  end
+
   class ArtistSerializer
     include RestPack::Serializer
     attributes :id, :name, :website


### PR DESCRIPTION
Replaces pull request #77 with this squashed version and also addresses #72 without the extra has_many :through code.
