### PR TITLE
Enable side-loading of has_many, through associated resources.

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -71,6 +71,11 @@ module RestPack
           if foreign_key_value
             data[:links][association.name.to_sym] = foreign_key_value.to_s
           end
+        elsif association.macro == :has_many && association.options[:through]
+          ids = model.send(association.name).pluck(:id).map { |id| id.to_s }
+
+          data[:links] ||= {}
+          data[:links][association.name.to_sym] = ids
         end
       end
       data

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -41,6 +41,13 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table "payments", :force => true do |t|
     t.integer "amount"
     t.integer  "artist_id"
+    t.integer  "fan_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "fans", :force => true do |t|
+    t.string "name"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -53,6 +60,7 @@ module MyApp
     has_many :albums
     has_many :songs
     has_many :payments
+    has_many :fans, :through => :payments
   end
 
   class Album < ActiveRecord::Base
@@ -82,5 +90,12 @@ module MyApp
     attr_accessible :amount, :artist
 
     belongs_to :artist
+    belongs_to :fan
+  end
+
+  class Fan < ActiveRecord::Base
+    attr_accessible :name
+    has_many :payments
+    has_many :artists, :through => :albums
   end
 end

--- a/spec/fixtures/serializers.rb
+++ b/spec/fixtures/serializers.rb
@@ -27,6 +27,11 @@ module MyApp
   class ArtistSerializer
     include RestPack::Serializer
     attributes :id, :name, :website
-    can_include :albums, :songs
+    can_include :albums, :songs, :fans
+  end
+
+  class FanSerializer
+    include RestPack::Serializer
+    attributes :id, :name
   end
 end

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -139,14 +139,30 @@ describe RestPack::Serializer do
     end
 
     context "links" do
-      let(:serializer) { MyApp::SongSerializer.new }
-      it "includes 'links' data" do
-        @album1 = FactoryGirl.create(:album_with_songs, song_count: 11)
-        json = serializer.as_json(@album1.songs.first)
-        json[:links].should == {
-          artist: @album1.artist_id.to_s,
-          album: @album1.id.to_s
-        }
+      context "'belongs to' associations" do
+        let(:serializer) { MyApp::SongSerializer.new }
+
+        it "includes 'links' data for :belongs_to associations" do
+          @album1 = FactoryGirl.create(:album_with_songs, song_count: 11)
+          json = serializer.as_json(@album1.songs.first)
+          json[:links].should == {
+            artist: @album1.artist_id.to_s,
+            album: @album1.id.to_s
+          }
+        end
+      end
+
+      context "'has_many, through' associations" do
+        let(:artist_serializer) { MyApp::ArtistSerializer.new }
+
+        it "includes 'links' data when there are associated records" do
+          artist_with_fans = FactoryGirl.create :artist_with_fans
+
+          json = artist_serializer.as_json(artist_with_fans)
+          json[:links].should == {
+            fans: artist_with_fans.fans.collect {|obj| obj.id.to_s }
+          }
+        end
       end
     end
   end

--- a/spec/serializable/side_loading/has_many_spec.rb
+++ b/spec/serializable/side_loading/has_many_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 describe RestPack::Serializer::SideLoading do
   context "when side-loading" do
+    let(:side_loads) { MyApp::ArtistSerializer.side_loads(models, options) }
+
     describe ".has_many" do
 
       before(:each) do
         @artist1 = FactoryGirl.create(:artist_with_albums, album_count: 2)
         @artist2 = FactoryGirl.create(:artist_with_albums, album_count: 1)
       end
-      let(:side_loads) { MyApp::ArtistSerializer.side_loads(models, options) }
 
       context "with a single model" do
         let(:models) { [@artist1] }
@@ -37,7 +38,35 @@ describe RestPack::Serializer::SideLoading do
           end
         end
       end
+    end
 
+    describe '.has_many through' do
+      context 'when including :fans' do
+        let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "fans" }) }
+        let(:artist_1) {FactoryGirl.create :artist_with_fans}
+        let(:artist_2) {FactoryGirl.create :artist_with_fans}
+
+        context "with a single model" do
+          let(:models) {[artist_1]}
+
+          it 'returns side-loaded fans' do
+            side_loads[:fans].count.should == artist_1.fans.count
+            side_loads[:meta][:fans][:page].should == 1
+            side_loads[:meta][:fans][:count].should == artist_1.fans.count
+          end
+        end
+        context "with a multiple models" do
+          let(:models) {[artist_1, artist_2]}
+
+          it 'returns side-loaded fans' do
+            expected_count = artist_1.fans.count  + artist_2.fans.count
+
+            side_loads[:fans].count.should == expected_count
+            side_loads[:meta][:fans][:page].should == 1
+            side_loads[:meta][:fans][:count].should == expected_count
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -14,6 +14,15 @@ FactoryGirl.define do
         create_list(:album_with_songs, evaluator.album_count, artist: artist)
       end
     end
+
+    factory :artist_with_fans do
+      ignore do
+        fans_count 3
+      end
+      after(:create) do |artist, evaluator|
+        create_list(:payment, evaluator.fans_count, artist: artist)
+      end
+    end
   end
 
   factory :album, :class => MyApp::Album do
@@ -41,5 +50,10 @@ FactoryGirl.define do
   factory :payment, :class => MyApp::Payment do
     amount 999
     artist
+    fan
+  end
+
+  factory :fan, :class => MyApp::Fan do
+    sequence(:name) {|n| "Fan ##{n}"}
   end
 end


### PR DESCRIPTION
This PR updates the restpack serializer to properly handle has_many through associations. I added tests to demonstrate that it was previously broken but is now fixed.
