### PR TITLE
resource links on a  polymorphic belongs_to association

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -67,7 +67,11 @@ module RestPack
       self.class.associations.each do |association|
         if association.macro == :belongs_to
           data[:links] ||= {}
-          foreign_key_value = model.send(association.foreign_key)
+          foreign_key_value = if association.polymorphic?
+            model.send(association.name).to_param
+          else
+            model.send(association.foreign_key)
+          end
           if foreign_key_value
             data[:links][association.name.to_sym] = foreign_key_value.to_s
           end


### PR DESCRIPTION
I wanted to start a discussion around how to handle a polymorphic belongs_to relation on a resource. 

Just returning the FK id doesn't contain the polymorphic context of the linked resource, resulting in an ambiguous link. I've implemented a simple fix that fits my needs as my polymorphic association target overrides the to_param method however if the association target doesn't then this problem still remains. 

Perhaps there is a better way of embedding the association type in the links hash? Thoughts?