### PR TITLE
Moves protected attributes gem dependency to development.

### DIFF
--- a/lib/restpack_serializer.rb
+++ b/lib/restpack_serializer.rb
@@ -1,5 +1,4 @@
 require 'kaminari'
-require 'protected_attributes'
 
 require 'restpack_serializer/version'
 require 'restpack_serializer/configuration'

--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', ['>= 4.0.3', '< 5.0']
   gem.add_dependency 'activerecord', ['>= 4.0.3', '< 5.0']
-  gem.add_dependency 'protected_attributes', '~> 1.0.5'
   gem.add_dependency 'kaminari', '~> 0.15.1'
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
@@ -31,4 +30,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'database_cleaner', '~> 1.0.1'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'bump'
+  gem.add_development_dependency 'protected_attributes', '~> 1.0.5'
 end


### PR DESCRIPTION
Protected Attributes appears to be a testing dependency. This conflicts with other mass assignment strategies such as Strong Parameters in Rails 4.
