### PR TITLE
Fix small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ end
 }
 ```
 
-`as_json` accepts an optional `context` hash parameter which can be used be your Serializers to customize their output:
+`as_json` accepts an optional `context` hash parameter which can be used by your Serializers to customize their output:
 
 ```ruby
 class AlbumSerializer


### PR DESCRIPTION
I was just going through the README and noticed this small typo: 

`can be used be` should be `can be used by`.
