### PR TITLE
Update resource links to behave consistently

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -71,7 +71,7 @@ module RestPack
           if foreign_key_value
             data[:links][association.name.to_sym] = foreign_key_value.to_s
           end
-        elsif association.macro == :has_many && association.options[:through]
+        elsif association.macro == :has_many
           ids = model.send(association.name).pluck(:id).map { |id| id.to_s }
 
           data[:links] ||= {}

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -133,7 +133,7 @@ describe RestPack::Serializer::Paging do
         album_model = MyApp::Album.find(album[:id])
 
         album[:links][:artist].should == album_model.artist_id.to_s
-        album[:links][:songs].should == page[:songs].map { |song| song[:id] }
+        (page[:songs].map { |song| song[:id] } - album[:links][:songs]).empty?.should be_truthy
       end
 
       context "with includes as comma delimited string" do

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -159,9 +159,7 @@ describe RestPack::Serializer do
           artist_with_fans = FactoryGirl.create :artist_with_fans
 
           json = artist_serializer.as_json(artist_with_fans)
-          json[:links].should == {
-            fans: artist_with_fans.fans.collect {|obj| obj.id.to_s }
-          }
+          json[:links][:fans].should == artist_with_fans.fans.collect {|obj| obj.id.to_s }
         end
       end
     end


### PR DESCRIPTION
This fixes the inconsistency of resource links by association type, making has_many behave the same as has_many :through and belongs_to. With this code change, all resource-embedded links are shown automatically. The "linked" section remains unpopulated unless the associated resource is included via params.

This would resolve [Issue #82](https://github.com/RestPack/restpack_serializer/issues/82): Inconsistent behavior with has_many and belong_to links.
