### PR TITLE
Storing attribute options so they can be accessed later

### DIFF
--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -10,15 +10,23 @@ module RestPack::Serializer::Attributes
       @serializable_attributes
     end
 
+     def serializable_attributes_options
+      @serializable_attributes_options
+    end
+
     def attributes(*attrs)
       attrs.each { |attr| attribute attr }
     end
 
     def attribute(name, options={})
-      options[:key] ||= name.to_sym
+      key = options[:key] || name.to_sym
+      options.delete :key
 
       @serializable_attributes ||= {}
-      @serializable_attributes[options[:key]] = name
+      @serializable_attributes[key] = name
+
+      @serializable_attributes_options ||= {}
+      @serializable_attributes_options[key] = options
 
       define_attribute_method name
       define_include_method name

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -5,14 +5,16 @@ describe RestPack::Serializer::Attributes do
 		include RestPack::Serializer
 		attributes :a, :b, :c
 		attribute :old_attribute, :key => :new_key
+		attribute :number, { type: :decimal, async: true }
 	end
 
 	before do
 		@attributes = CustomSerializer.serializable_attributes
+		@options = CustomSerializer.serializable_attributes_options
 	end
 
 	it "correctly models specified attributes" do
-		@attributes.length.should == 4
+		@attributes.length.should == 5
 	end
 
 	it "correctly maps normal attributes" do
@@ -23,5 +25,14 @@ describe RestPack::Serializer::Attributes do
 
 	it "correctly maps attribute with :key options" do
 		@attributes[:new_key].should == :old_attribute
+	end
+
+	it "correctly matches passed through options" do
+		@options[:number][:type].should == :decimal
+		@options[:number][:async].should == true
+	end
+
+	it "correctly removed key from options" do
+		@options[:new_key].has_key?(:key).should == false
 	end
 end


### PR DESCRIPTION
We have the need to store additional metadata associated with the attribute when the serializer is setup. This adds the option to pass additional parameters through and then access them later. 
