### PR TITLE
force sideloaded associated models to have fixed page size

### DIFF
--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -47,6 +47,7 @@ module RestPack
         return {} if @models.empty?
         serializer_class = @serializer.class
         options = RestPack::Serializer::Options.new(serializer_class)
+        options.page_size=1000
         yield options
         options.include_links = false
         serializer_class.page_with_options(options)


### PR DESCRIPTION
This is  something I did a while ago. It is a hack to allow all of my sideloaded resources of a paged model to be loaded rather than just the same total number as the primary resource. 

Currently what appears to happen is that you get the page size number of sideloads which isn't what I want.

Ideally the page size would apply to the individual items in the paged model, but I couldn't figure out the sql to do that in one call and I didn't want to be doing a call per model, so I rolled back the option code I wrote to allow it to be passed in.

I think primarily this is an sql problem.

It is an ugly hack, so I'd like to see something nicer. 
