### PR TITLE
Add option to as_json to allow links to be omitted

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -32,13 +32,13 @@ module RestPack
 
     class InvalidInclude < Exception; end
 
-    def as_json(model, context = {})
+    def as_json(model, context = {}, options={})
       return if model.nil?
       if model.kind_of?(Array)
         return model.map { |item| as_json(item, context) }
       end
 
-      @model, @context = model, context
+      @model, @context, @options = model, context, options
 
       data = {}
       if self.class.serializable_attributes.present?
@@ -65,6 +65,7 @@ module RestPack
     end
 
     def add_links(model, data)
+      return if @options[:no_links]
       self.class.associations.each do |association|
         data[:links] ||= {}
         links_value = case
@@ -91,8 +92,8 @@ module RestPack
         new.as_json(models, context)
       end
 
-      def as_json(model, context = {})
-        new.as_json(model, context)
+      def as_json(model, context = {}, options={})
+        new.as_json(model, context, options)
       end
 
       def serialize(models, context = {})


### PR DESCRIPTION
I am using as_json to include nested resources and typically I don't want the links.

Therefore I added and options param to allow this to be specified and in a serializer i can go:

```
 def user
    UserSerializer.as_json(@model.user, {}, no_links: true)
 end
```

Not sure if this screws up something else, but all tests passing so far....
