### PR TITLE
avoid_multiple_db_calls_for_links

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -71,7 +71,7 @@ module RestPack
         when association.macro == :belongs_to
           model.send(association.foreign_key).try(:to_s)
         when association.macro.to_s.match(/has_/)
-          model.send(association.name).pluck(:id).map(&:to_s)
+          model.send(association.name).map{|m| m.id.to_s}
         end
         unless links_value.blank?
           data[:links][association.name.to_sym] = links_value


### PR DESCRIPTION
pluck causes a db call to be made even if the associated resource has already been loaded using an activerecord includes. 
This patch changes that, but makes it less efficient if the resource hasn't already been loaded.
In most cases I would have thought that includes should have been used, so I think this might be better.
