### PR TITLE
avoid n+1 queries in add_links when an association is eager loaded

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -71,7 +71,11 @@ module RestPack
         when association.macro == :belongs_to
           model.send(association.foreign_key).try(:to_s)
         when association.macro.to_s.match(/has_/)
-          model.send(association.name).pluck(:id).map(&:to_s)
+          if model.send(association.name).loaded?
+            model.send(association.name).collect { |associated| associated.id.to_s }
+          else
+            model.send(association.name).pluck(:id).map(&:to_s)
+          end
         end
         unless links_value.blank?
           data[:links][association.name.to_sym] = links_value

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -153,12 +153,23 @@ describe RestPack::Serializer do
       end
 
       context "with a serializer with has_* associations" do
+        let(:artist_factory) { FactoryGirl.create :artist_with_fans }
         let(:artist_serializer) { MyApp::ArtistSerializer.new }
         let(:json) { artist_serializer.as_json(artist_factory) }
         let(:side_load_ids) { artist_has_association.map {|obj| obj.id.to_s } }
 
+        context "when the association has been eager loaded" do
+          before do
+            artist_factory.fans.stub(:loaded?) { true }
+          end
+          it "does not make a query to retrieve id values" do
+            expect(artist_factory.fans).not_to receive(:pluck)
+            json
+          end
+        end
+
+
         describe "'has_many, through' associations" do
-          let(:artist_factory) { FactoryGirl.create :artist_with_fans }
           let(:artist_has_association) { artist_factory.fans }
 
           it "includes 'links' data when there are associated records" do


### PR DESCRIPTION
This addresses the same problem as #98 
The difference is that if an association has not been eager loaded, it falls back to the pluck query so it will only load ids instead of full objects.
Probably the right thing to do is force eager loading of associations, rather than rely on the user passing a scope which eager loads them. However that's a little bit more work and I'm still getting familiar with this project.
