### PR TITLE
option to individually configure href_prefix in serializers

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -89,7 +89,7 @@ module RestPack
     end
 
     module ClassMethods
-      attr_accessor :model_class, :key
+      attr_accessor :model_class, :href_prefix, :key
 
       def array_as_json(models, context = {})
         new.as_json(models, context)
@@ -109,6 +109,10 @@ module RestPack
 
       def model_class
         @model_class || self.name.chomp('Serializer').constantize
+      end
+
+      def href_prefix
+        @href_prefix || RestPack::Serializer.config.href_prefix
       end
 
       def key

--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -2,7 +2,7 @@ module RestPack::Serializer::Attributes
   extend ActiveSupport::Concern
 
   def default_href
-    "#{RestPack::Serializer.config.href_prefix}/#{self.class.key}/#{@model.to_param}"
+    "#{self.class.href_prefix}/#{self.class.key}/#{@model.to_param}"
   end
 
   module ClassMethods

--- a/lib/restpack_serializer/serializable/paging.rb
+++ b/lib/restpack_serializer/serializable/paging.rb
@@ -54,7 +54,7 @@ module RestPack::Serializer::Paging
     def page_href(page, options)
       return nil unless page
 
-      url = "#{RestPack::Serializer.config.href_prefix}/#{self.key}"
+      url = "#{self.href_prefix}/#{self.key}"
 
       params = []
       params << "page=#{page}" unless page == 1

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -34,8 +34,9 @@ module RestPack::Serializer::SideLoading
             link_key = "#{self.key}.#{association.plural_name}"
             href = "/#{association.plural_name}?#{singular_key}_id={#{key}.id}"
           end
+
           links.merge!(link_key => {
-            :href => RestPack::Serializer.config.href_prefix + href,
+            :href => href_prefix + href,
             :type => association.plural_name.to_sym
             }
           )

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -37,6 +37,22 @@ describe RestPack::Serializer::Paging do
       end
     end
 
+    context 'when href prefix is set' do
+      before do
+        @original_prefix = MyApp::SongSerializer.href_prefix
+        MyApp::SongSerializer.href_prefix = '/api/v3'
+      end
+      after do
+        MyApp::SongSerializer.href_prefix = @original_prefix
+      end
+      let(:page) do
+        MyApp::SongSerializer.page(params, scope, context)
+      end
+      it 'should use prefixed links' do
+        page[:meta][:songs][:next_href].should == '/api/v3/songs?page=2'
+      end
+    end
+
     context "with custom page size" do
       let(:params) { { page_size: '3' } }
       it "returns custom page sizes" do

--- a/spec/serializable/side_loading/side_loading_spec.rb
+++ b/spec/serializable/side_loading/side_loading_spec.rb
@@ -67,6 +67,13 @@ describe RestPack::Serializer::SideLoading do
       MyApp::AlbumSerializer.links["albums.artist"][:href].should == "/api/v1/artists/{albums.artist}"
       RestPack::Serializer.config.href_prefix = original
     end
+
+    it "applies custom serializer  href_prefix" do
+      original = RestPack::Serializer.config.href_prefix
+      MyApp::AlbumSerializer.href_prefix = '/api/v2'
+      MyApp::AlbumSerializer.links["albums.artist"][:href].should == "/api/v2/artists/{albums.artist}"
+      MyApp::AlbumSerializer.href_prefix = original
+    end
   end
 
   describe "#filterable_by" do


### PR DESCRIPTION
for example if you have multiple API versions, you want one group
to use prefix `/api/v1` other `/api/v2` and so on.

Global configuration allow only one prefix
