### PR TITLE
ensure side loaded models are distinct for has_many :through

### DIFF
--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -18,7 +18,7 @@ module RestPack
       def side_load_has_many
         has_association_relation do |options|
           if join_table = @association.options[:through]
-            options.scope = options.scope.joins(join_table)
+            options.scope = options.scope.joins(join_table).distinct
             association_fk = @association.through_reflection.foreign_key.to_sym
             options.filters = { join_table => { association_fk => model_ids } }
           else

--- a/spec/serializable/side_loading/has_many_spec.rb
+++ b/spec/serializable/side_loading/has_many_spec.rb
@@ -65,6 +65,17 @@ describe RestPack::Serializer::SideLoading do
             side_loads[:meta][:fans][:page].should == 1
             side_loads[:meta][:fans][:count].should == expected_count
           end
+
+          context "when there are shared fans" do
+            before do
+              artist_1.fans << artist_2.fans.first
+            end
+            it "should not include duplicates in the linked resource collection" do
+              expected_count = (artist_1.fans + artist_2.fans).uniq.count
+              expect(side_loads[:fans].count).to eq(expected_count)
+              expect(side_loads[:meta][:fans][:count]).to eq(expected_count)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Currently when you side load models from a many to many relationship you will get duplicates if two source models both are related to the same side loaded model. This fixes the problem by adding a distinct to the side loading query scope.

I did run into one problem using this myself, which is that distinct does not work on postgres tables which contain a JSON type column. Still thinking about a workaround for that, but since restpack has no other dbms specific code, I figured it might be worthwhile to merge as is since it fixes the general case.