### PR TITLE
Don't convert user supplied include to symbols

### DIFF
--- a/lib/restpack_serializer/options.rb
+++ b/lib/restpack_serializer/options.rb
@@ -9,7 +9,7 @@ module RestPack::Serializer
 
       @page = params[:page] ? params[:page].to_i : 1
       @page_size = params[:page_size] ? params[:page_size].to_i : RestPack::Serializer.config.page_size
-      @include = params[:include] ? params[:include].split(',').map(&:to_sym) : []
+      @include = params[:include] ? params[:include].split(',') : []
       @filters = filters_from_params(params, serializer)
       @sorting = sorting_from_params(params, serializer)
       @serializer = serializer

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -68,7 +68,7 @@ module RestPack::Serializer::SideLoading
     end
 
     def association_from_include(include)
-      raise_invalid_include(include) unless self.can_includes.include?(include)
+      raise_invalid_include(include) unless can_include?(include)
       possible_relations = [include.to_s.singularize.to_sym, include]
       select_association_from_possibles(possible_relations)
     end
@@ -80,6 +80,12 @@ module RestPack::Serializer::SideLoading
         end
       end
       raise_invalid_include(include)
+    end
+
+    def can_include?(include)
+      !!self.can_includes.index do |can_include|
+        can_include == include || can_include.to_s == include
+      end
     end
 
     def raise_invalid_include(include)

--- a/spec/serializable/options_spec.rb
+++ b/spec/serializable/options_spec.rb
@@ -24,7 +24,7 @@ describe RestPack::Serializer::Options do
 
   describe 'with include' do
     let(:params) { { 'include' => 'model1,model2' } }
-    it { subject.include.should == [:model1, :model2] }
+    it { subject.include.should == ["model1", "model2"] }
   end
 
   context 'with filters' do

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -135,7 +135,7 @@ describe RestPack::Serializer::Paging do
       end
 
       it "includes the side-loads in the main meta data" do
-        page[:meta][:songs][:include].should == [:albums]
+        page[:meta][:songs][:include].should == ["albums"]
       end
 
       it "includes the side-loads in page hrefs" do

--- a/spec/serializable/resource_spec.rb
+++ b/spec/serializable/resource_spec.rb
@@ -33,7 +33,7 @@ describe RestPack::Serializer::Resource do
     end
 
     it "includes the side-loads in the main meta data" do
-      resource[:meta][:songs][:include].should == [:albums]
+      resource[:meta][:songs][:include].should == ["albums"]
     end
   end
 


### PR DESCRIPTION
Avoids a possible memory leak by leaving the user specified params[:include]
as a string. Instead adds a `::can_include?` method that tests specified
includes as both strings and symbols.

Closes #85