### PR TITLE
Allow customization of has_many link parameters

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -56,6 +56,10 @@ module RestPack
     def custom_attributes
       {}
     end
+    
+    def url
+      self.class.url
+    end
 
     private
 
@@ -125,6 +129,11 @@ module RestPack
 
       def plural_key
         self.key
+      end
+
+      def url(path=nil)
+        return @url || plural_key unless path
+        @url = path
       end
     end
   end

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -19,24 +19,25 @@ module RestPack::Serializer::SideLoading
     end
 
     def can_include(*includes)
+      @can_include_options = {}
+      @can_include_options = includes.last if includes.last.is_a?(Hash)
       @can_includes ||= []
-      @can_includes += includes
+      @can_includes += includes.flat_map do
+        |include| include.try(:keys)|| include
+      end
     end
-
+ 
     def links
       {}.tap do |links|
         associations.each do |association|
-          if association.macro == :belongs_to
-            link_key = "#{self.key}.#{association.name}"
-            href = "/#{association.plural_name}/{#{link_key}}"
+          link_key = if association.macro == :belongs_to
+            "#{key}.#{association.name}"
           elsif association.macro.to_s.match(/has_/)
-            singular_key = self.key.to_s.singularize
-            link_key = "#{self.key}.#{association.plural_name}"
-            href = "/#{association.plural_name}?#{singular_key}_id={#{key}.id}"
+            "#{key}.#{association.plural_name}"
           end
-
+          
           links.merge!(link_key => {
-            :href => href_prefix + href,
+            :href => href_prefix + url_for_association(association),
             :type => association.plural_name.to_sym
             }
           )
@@ -56,7 +57,7 @@ module RestPack::Serializer::SideLoading
     def side_load(include, models, options)
       association = association_from_include(include)
       return {} unless supported_association?(association.macro)
-      serializer = RestPack::Serializer::Factory.create(association.class_name)
+      serializer = serializer_from_association_class(association)
       builder = RestPack::Serializer::SideLoadDataBuilder.new(association,
                                                               models,
                                                               serializer)
@@ -85,6 +86,31 @@ module RestPack::Serializer::SideLoading
     def raise_invalid_include(include)
       raise RestPack::Serializer::InvalidInclude.new,
         ":#{include} is not a valid include for #{self.model_class}"
+    end
+
+    def url_from_association(association)
+      serializer_from_association_class(association).url
+    end
+    
+    def url_for_association(association)
+      identifier = if association.macro == :belongs_to
+        "/{#{key}.#{association.name}}"
+      else association.macro.to_s.match(/has_/)
+        param = can_include_options(association)[:param] || "#{singular_key}_id"
+        value = can_include_options(association)[:value] || "id"
+      
+        "?#{param}={#{key}.#{value}}"
+      end
+
+      "/#{url_from_association(association)}#{identifier}"
+    end
+
+    def can_include_options(association)
+      @can_include_options.fetch(association.name.to_sym, {})
+    end
+
+    def serializer_from_association_class(association)
+      RestPack::Serializer::Factory.create(association.class_name)
     end
   end
 end

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string   "title"
     t.integer  "year"
     t.integer  "artist_id"
+    t.string "producer"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -62,6 +63,11 @@ ActiveRecord::Schema.define(:version => 1) do
     t.integer :artist_id
     t.integer :stalker_id
   end
+
+  create_table "producers", force: true do |t|
+    t.string :name
+    t.string :album
+  end
 end
 
 module MyApp
@@ -82,6 +88,7 @@ module MyApp
     belongs_to :artist
     has_many :songs
     has_many :album_reviews
+    has_many :producers, foreign_key: :album
   end
 
   class AlbumReview < ActiveRecord::Base
@@ -114,5 +121,10 @@ module MyApp
   class Stalker < ActiveRecord::Base
     attr_accessible :name
     has_and_belongs_to_many :artists
+  end
+
+  class Producer < ActiveRecord::Base
+    attr_accessible :name
+    belongs_to :album, foreign_key: :album
   end
 end

--- a/spec/fixtures/serializers.rb
+++ b/spec/fixtures/serializers.rb
@@ -2,7 +2,7 @@ module MyApp
   class SongSerializer
     include RestPack::Serializer
     attributes :id, :title, :album_id
-    can_include :albums, :artists
+    can_include :artists, :albums
     can_filter_by :title
     can_sort_by :id, :title
 
@@ -14,7 +14,7 @@ module MyApp
   class AlbumSerializer
     include RestPack::Serializer
     attributes :id, :title, :year, :artist_id
-    can_include :artists, :songs
+    can_include :artists, :songs, producers: { param: "album", value: "title" }
     can_filter_by :year
   end
 
@@ -36,6 +36,11 @@ module MyApp
   end
 
   class StalkerSerializer
+    include RestPack::Serializer
+    attributes :id, :name
+  end
+
+  class ProducerSerializer 
     include RestPack::Serializer
     attributes :id, :name
   end

--- a/spec/serializable/side_loading/side_loading_spec.rb
+++ b/spec/serializable/side_loading/side_loading_spec.rb
@@ -58,6 +58,10 @@ describe RestPack::Serializer::SideLoading do
       "albums.songs" => {
         :href => "/songs?album_id={albums.id}",
         :type => :songs
+      },
+      "albums.producers" => {
+        :href => "/producers?album={albums.title}",
+        :type => :producers
       }
     }
 
@@ -73,6 +77,12 @@ describe RestPack::Serializer::SideLoading do
       MyApp::AlbumSerializer.href_prefix = '/api/v2'
       MyApp::AlbumSerializer.links["albums.artist"][:href].should == "/api/v2/artists/{albums.artist}"
       MyApp::AlbumSerializer.href_prefix = original
+    end
+
+    it "applies a custom url to links" do
+      MyApp::ProducerSerializer.url("prods")
+      MyApp::AlbumSerializer.links["albums.producers"][:href].should == "/prods?album={albums.title}"
+      MyApp::ProducerSerializer.url("producers")
     end
   end
 


### PR DESCRIPTION
I have a case where I need the parameters for has_many links to be different than the default. 

Given the models Project and User where a user has many projects, rest pack would include a link with an href like `/projects?user_id={users.id}`. I'd like to do something like `/projects?owner={user.name}`. 

This PR just allows a hash of options to be included with each link passed  to `can_include` like so:

``` ruby
class UserSerializer
  include RestPack::Serializer

  can_include projects: { param: "owner", value: "name" }
```
