### PR TITLE
Don't attempt to side load a null record in a belongs_to association

### DIFF
--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -9,8 +9,8 @@ module RestPack
       end
 
       def side_load_belongs_to
-        foreign_keys = @models.map { |model| model.send(@association.foreign_key) }.uniq
-        side_load = @association.klass.find(foreign_keys)
+        foreign_keys = @models.map { |model| model.send(@association.foreign_key) }.uniq.compact
+        side_load = foreign_keys.any? ? @association.klass.find(foreign_keys) : []
         json_model_data = side_load.map { |model| @serializer.as_json(model) }
         { @association.plural_name.to_sym => json_model_data, meta: { } }
       end

--- a/spec/serializable/side_loading/belongs_to_spec.rb
+++ b/spec/serializable/side_loading/belongs_to_spec.rb
@@ -67,6 +67,19 @@ describe RestPack::Serializer::SideLoading do
         end
       end
 
+      context 'without an associated model' do
+        let!(:b_side) { FactoryGirl.create(:song, album: nil) }
+        let(:models) { [b_side] }
+
+        context 'when including :albums' do
+          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "albums" }) }
+
+          it 'return a hash with no data' do
+            side_loads.should == { :meta => {}, :albums => [] }
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
I'm not sure if this behavior was intentional, but I came across what is probably a bug.

In terms of the models in the specs: given a Song without an album, side-loading the Album attempts to find a record with a nil id.