### PR TITLE
Add support for Rails autoloading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ restpack_serializer allows you to quickly provide a set of RESTful endpoints for
 ## Getting Started
 
 ### For rails projects:
-After adding the gem `restpack_serializer` to your Gemfile, add this code to `config/initializers/restpack_serializer.rb`:
+Rails autoloading will automatically pull in top-level serializers. This means you no longer need to restart your server when changing serializers in development. If you previously had a restpack serializer initializer script, please remove it, as the two are not compatible.
+
+If your serializers or your model classes are nested in a module, you'll need to make sure you add this to your project in `config/initializers/restpack_serializer.rb`:
 
 ```ruby
 Dir[Rails.root.join('app/serializers/**/*.rb')].each do |path|

--- a/lib/restpack_serializer/factory.rb
+++ b/lib/restpack_serializer/factory.rb
@@ -9,7 +9,7 @@ class RestPack::Serializer::Factory
   def self.classify(identifier)
     normalised_identifier = identifier.to_s.underscore
     [normalised_identifier, normalised_identifier.singularize].each do |format|
-      klass = RestPack::Serializer.class_map[format]
+      klass = RestPack::Serializer.class_for_identifier(format)
       return klass.new if klass
     end
 

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -13,13 +13,23 @@ require_relative "serializable/sortable"
 module RestPack
   module Serializer
     extend ActiveSupport::Concern
-    mattr_accessor :class_map
+
     @@class_map ||= {}
 
     included do
       identifier = self.to_s.underscore.chomp('_serializer')
       @@class_map[identifier] = self
       @@class_map[identifier.split('/').last] = self
+    end
+
+    def self.class_for_identifier(identifier)
+      klass = begin
+        "#{identifier}_serializer".camelize.constantize
+      rescue NameError => e
+        nil
+      end
+
+      klass ||= @@class_map[identifier]
     end
 
     include RestPack::Serializer::Paging


### PR DESCRIPTION
This PR should resolve Issue #111.

This enables Rails autoloading of the serializers as long as they are a top-level resource (not namespaced). Namespaced serializers still work, but do not get autoloaded. We think solving this problem for namespaced serializers/models will take a bigger refactor. @GavinJoyce do you have ideas on that?

There could be a performance impact from this change, since it's constantizing things rather than caching them.