### PR TITLE
added support for optional_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ end
 class AlbumSerializer
   include RestPack::Serializer
   attributes :id, :title, :year, :artist_id, :extras
+  optional :score
+
   can_include :artists, :songs
   can_filter_by :year
 
@@ -76,6 +78,18 @@ end
 
 ```ruby
 AlbumSerializer.as_json(album, { admin?: true })
+```
+
+All `attributes` are serialized by default. If you'd like to skip an attribute, you can pass an option in the `@context` as follows:
+
+```ruby
+AlbumSerializer.as_json(album, { include_title?: false })
+```
+
+You can also define `optional` attributes which aren't included by default. To include:
+
+```ruby
+AlbumSerializer.as_json(album, { include_score?: true })
 ```
 
 ## Exposing an API
@@ -114,8 +128,7 @@ AlbumSerializer.page(params, Albums.where("year < 1950"), { admin?: true })
 ```
 
 Other features:
- * [Dynamically Include/Exclude Attributes](https://github.com/RestPack/restpack_serializer/blob/master/spec/serializable/serializer_spec.rb#L42)
- * [Custom Attributes Hash](https://github.com/RestPack/restpack_serializer/blob/master/spec/serializable/serializer_spec.rb#L46)
+ * [Custom Attributes Hash](https://github.com/RestPack/restpack_serializer/blob/master/spec/serializable/serializer_spec.rb#L55)
 
 ## Paging
 

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -4,6 +4,8 @@ describe RestPack::Serializer::Attributes do
   class CustomSerializer
     include RestPack::Serializer
     attributes :a, :b, :c
+    attributes :d, :e
+    optional :sometimes, :maybe
     attribute :old_attribute, :key => :new_key
     transform [:gonzaga], lambda { |name, model| model.send(name).downcase }
   end
@@ -11,17 +13,37 @@ describe RestPack::Serializer::Attributes do
   subject(:attributes) { CustomSerializer.serializable_attributes }
 
   it "correctly models specified attributes" do
-    expect(attributes.length).to be(5)
+    expect(attributes.length).to be(9)
   end
 
   it "correctly maps normal attributes" do
-    [:a, :b, :c].each do |attr|
+    [:a, :b, :c, :d, :e].each do |attr|
       expect(attributes[attr]).to eq(attr)
     end
   end
 
   it "correctly maps attribute with :key options" do
     expect(attributes[:new_key]).to eq(:old_attribute)
+  end
+
+  describe "optional attributes" do
+    let(:model) { OpenStruct.new(a: 'A', sometimes: 'SOMETIMES', gonzaga: 'GONZAGA') }
+    let(:context) { {} }
+    subject(:as_json) { CustomSerializer.as_json(model, context) }
+
+    context 'with no includes context' do
+      it "excludes by default" do
+        expect(as_json[:sometimes]).to eq(nil)
+      end
+    end
+
+    context 'with an includes context' do
+      let(:context) { { include_sometimes?: true } }
+
+      it "allows then to be included" do
+        expect(as_json[:sometimes]).to eq('SOMETIMES')
+      end
+    end
   end
 
   describe '#transform_attributes' do


### PR DESCRIPTION
This adds support for `optional` attributes:

```ruby
class PersonSerializer
    include RestPack::Serializer

    attributes :id, :name
    optional :description
end
```

By default, `description` won't be serialized. To force inclusion:

```ruby
PersonSerializer.as_json(album, { include_description?: true })
```

closes https://github.com/RestPack/restpack_serializer/issues/116

TODO: 

 * [x] Update the readme

/fyi @eugeneius