### PR TITLE
models can now be hashes

### DIFF
--- a/lib/restpack_serializer/serializable/attributes.rb
+++ b/lib/restpack_serializer/serializable/attributes.rb
@@ -38,7 +38,11 @@ module RestPack::Serializer::Attributes
       unless method_defined?(name)
         define_method name do
           value = self.default_href if name == :href
-          value ||= @model.send(name)
+          if @model.is_a?(Hash)
+            value ||= @model[name] || @model[name.to_s]
+          else
+            value ||= @model.send(name)
+          end
           value = value.to_s if name == :id
           value
         end

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -33,4 +33,15 @@ describe RestPack::Serializer::Attributes do
       expect(as_json[:gonzaga]).to eq('is a school')
     end
   end
+
+  describe "model as a hash" do
+    let(:model) { { a: 'A', 'b' => 'B' } }
+
+    subject(:as_json) { CustomSerializer.as_json(model, include_gonzaga?: false) }
+
+    it 'uses the transform method on the model attribute' do
+      expect(as_json[:a]).to eq('A')
+      expect(as_json[:b]).to eq('B')
+    end
+  end
 end


### PR DESCRIPTION
closes https://github.com/RestPack/restpack_serializer/issues/95

This will allow us to remove attribute methods like:

```ruby
def name
  @model[:name]
end
```

/fyi @nolaneo