### PR TITLE
fixes #105 Sideloaded resources don't get passed parent resources context

### DIFF
--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -59,7 +59,8 @@ module RestPack::Serializer::SideLoading
       serializer = RestPack::Serializer::Factory.create(association.class_name)
       builder = RestPack::Serializer::SideLoadDataBuilder.new(association,
                                                               models,
-                                                              serializer)
+                                                              serializer,
+                                                              options)
       builder.send("side_load_#{association.macro}")
     end
 


### PR DESCRIPTION
In my application I have some resources I'd like to side load, but they require some additional context to serialize properly. Pushing down the root context to sideloaded resources as described in #105 works for me, and that's what this PR does. Ideally though I think the context should be namespaced somehow so you can apply the root context to the root serializer, and specific sideloaded resource contexts to their respective serializers. What do you think?