### PR TITLE
remove the symbolizer for a big perf win

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -50,6 +50,11 @@ module RestPack
       add_custom_attributes(data)
       add_links(model, data) unless self.class.associations.empty?
 
+      data
+    end
+
+    def as_json_symbolized(model, context = {})
+      data = as_json(model, context)
       Symbolizer.recursive_symbolize(data)
     end
 
@@ -97,6 +102,10 @@ module RestPack
 
       def as_json(model, context = {})
         new.as_json(model, context)
+      end
+
+      def as_json_symbolized(model, context = {})
+        new.as_json_symbolized(model, context)
       end
 
       def serialize(models, context = {})

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -33,7 +33,7 @@ describe RestPack::Serializer do
 
   class PersonSerializer
     include RestPack::Serializer
-    attributes :id, :name, :description, :href, :admin_info
+    attributes :id, :name, :description, :href, :admin_info, :string_keys
 
     def description
       "This is person ##{id}"
@@ -41,15 +41,29 @@ describe RestPack::Serializer do
 
     def admin_info
       {
-        "key" => "super_secret_sauce",
-        "array" => [
-          { "name" => "Alex" }
+        key: "super_secret_sauce",
+        array: [
+          { name: "Alex" }
         ]
       }
     end
 
     def include_admin_info?
       @context[:is_admin?]
+    end
+
+    def string_keys
+      {
+        "kid_b" => "Ben",
+        "likes" => {
+          "foods" => ["crackers", "stawberries"],
+          "books" => ["Dumpy", "That's Not My Tiger"]
+        }
+      }
+    end
+
+    def include_string_keys?
+      @context[:is_ben?]
     end
 
     def custom_attributes
@@ -185,6 +199,22 @@ describe RestPack::Serializer do
             expect(json[:links][:stalkers]).to match_array(side_load_ids)
           end
         end
+      end
+    end
+
+    describe ".as_json_symbolized" do
+      it "symbolizes keys recursively" do
+        serializer.as_json_symbolized(person, { is_ben?: true }).should == {
+          id: '123', name: 'Gavin', description: 'This is person #123',
+          href: '/people/123', custom_key: 'custom value for model id 123',
+          string_keys: {
+            kid_b: "Ben",
+            likes: {
+              foods: ["crackers", "stawberries"],
+              books: ["Dumpy", "That's Not My Tiger"]
+            }
+          }
+        }
       end
     end
   end


### PR DESCRIPTION
Symbolizing all keys is quite expensive and was only added to make writing serializer tests easier. I'm removing the `recursive_symbolize` call from the main `as_json` method, the symbolized output can be accessed with `as_json_symbolized`.

**before**

<img width="554" alt="screen shot 2016-05-06 at 14 22 34" src="https://cloud.githubusercontent.com/assets/2526/15074293/0e75b288-1396-11e6-8f33-93f4196e529c.png">

**after**

<img width="512" alt="screen shot 2016-05-06 at 14 22 42" src="https://cloud.githubusercontent.com/assets/2526/15074296/12f3929e-1396-11e6-89ad-67fb11292d02.png">
