### PR TITLE
better performance by tracking user defined methods

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -38,11 +38,22 @@ module RestPack
       end
 
       @model, @context = model, context
+      user_defined_methods = self.class.user_defined_methods
 
       data = {}
       if self.class.serializable_attributes.present?
-        self.class.serializable_attributes.each do |key, name|
-          data[key] = self.send(name) if include_attribute?(name)
+        self.class.serializable_attributes.each do |key, attribute|
+          method_name = attribute[:include_method_name]
+          name = attribute[:name]
+
+          if user_defined_methods.include?(method_name)
+            data[key] = self.send(name) if self.send(method_name)
+          else
+            #the default implementation of `include_abc?`
+            if @context[method_name].nil? || @context[method_name]
+              data[key] = self.send(name)
+            end
+          end
         end
       end
 
@@ -53,7 +64,7 @@ module RestPack
     end
 
     def custom_attributes
-      {}
+      nil
     end
 
     private
@@ -83,12 +94,16 @@ module RestPack
       data
     end
 
-    def include_attribute?(name)
-      self.send("include_#{name}?".to_sym)
-    end
-
     module ClassMethods
-      attr_accessor :model_class, :href_prefix, :key
+      attr_accessor :model_class, :href_prefix, :key, :user_defined_methods, :track_defined_methods
+
+      def method_added(name)
+        #we track used defined methods so that we can make quick decisions at runtime
+        @user_defined_methods ||= []
+        if @track_defined_methods
+          @user_defined_methods << name
+        end
+      end
 
       def array_as_json(models, context = {})
         new.as_json(models, context)

--- a/spec/serializable/attributes_spec.rb
+++ b/spec/serializable/attributes_spec.rb
@@ -18,12 +18,18 @@ describe RestPack::Serializer::Attributes do
 
   it "correctly maps normal attributes" do
     [:a, :b, :c, :d, :e, :f?].each do |attr|
-      expect(attributes[attr]).to eq(attr)
+      expect(attributes[attr]).to eq({
+        name: attr,
+        include_method_name: "include_#{attr}?".to_sym
+      })
     end
   end
 
   it "correctly maps attribute with :key options" do
-    expect(attributes[:new_key]).to eq(:old_attribute)
+    expect(attributes[:new_key]).to eq({
+      name: :old_attribute,
+      include_method_name: :include_new_key?
+    })
   end
 
   describe "optional attributes" do


### PR DESCRIPTION
/cc @lorcan

**before**

<img width="518" alt="screen shot 2016-05-10 at 13 40 42" src="https://cloud.githubusercontent.com/assets/2526/15146725/d7336b72-16b4-11e6-889d-31010d7f116f.png">

**after**

<img width="509" alt="screen shot 2016-05-10 at 13 40 03" src="https://cloud.githubusercontent.com/assets/2526/15146730/dca525aa-16b4-11e6-8167-2741017edb98.png">

---

and for comparison, here are the results from a couple of days ago:

<img width="512" alt="screen shot 2016-05-10 at 13 44 55" src="https://cloud.githubusercontent.com/assets/2526/15146865/75f3b35c-16b5-11e6-80dd-c4982f09666f.png">
