### PR TITLE
Delegate to_json to the serialized hash

### DIFF
--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -62,6 +62,10 @@ module RestPack
       data
     end
 
+    def to_json(model, context = {})
+      as_json(model, context).to_json
+    end
+
     def custom_attributes
       nil
     end
@@ -163,6 +167,10 @@ module RestPack
 
       def as_json(model, context = {})
         new.as_json(model, context)
+      end
+
+      def to_json(model, context = {})
+        new.as_json(model, context).to_json
       end
 
       def serialize(models, context = {})

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -313,6 +313,20 @@ describe RestPack::Serializer do
     end
   end
 
+  describe "to_json" do
+    context "class method" do
+      it "delegates to as_json" do
+        expect(PersonSerializer.as_json(person).to_json).to eq(PersonSerializer.to_json(person))
+      end
+    end
+
+    context "instance method" do
+      it "delegates to as_json" do
+        expect(serializer.as_json(person).to_json).to eq(serializer.to_json(person))
+      end
+    end
+  end
+
   describe "#model_class" do
     it "extracts the Model name from the Serializer name" do
       expect(PersonSerializer.model_class).to eq(Person)


### PR DESCRIPTION
Calling `to_json` on a serializer currently produces a different result depending on which JSON library is providing the method, because of the convention that `as_json` serializes `self`, rather than its arguments.

Concretely, the problem I ran into is that Active Support's JSON encoder calls `as_json` but duplicates the provided argument first, which caused the model I passed to forget that it was persisted:

https://github.com/rails/rails/blob/v5.2.0/activesupport/lib/active_support/json/encoding.rb#L35
https://github.com/rails/rails/blob/v5.2.0/activerecord/lib/active_record/core.rb#L385

By providing our own implementation of `to_json` that delegates to the result of `as_json`, we can ensure its behaviour is consistent across different JSON encoders.