### PR TITLE
Drop protected_attributes_continued development dependency

### DIFF
--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'database_cleaner', '~> 1.5'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'bump'
-  gem.add_development_dependency 'protected_attributes_continued', '~> 1.2'
 end

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -1,6 +1,5 @@
 require 'sqlite3'
 require 'active_record'
-require 'protected_attributes_continued'
 
 ActiveRecord::Base.establish_connection(
   :adapter => 'sqlite3',
@@ -66,8 +65,6 @@ end
 
 module MyApp
   class Artist < ActiveRecord::Base
-    attr_accessible :name, :website
-
     has_many :albums
     has_many :songs
     has_many :payments
@@ -76,7 +73,6 @@ module MyApp
   end
 
   class Album < ActiveRecord::Base
-    attr_accessible :title, :year, :artist
     scope :classic, -> { where("year < 1950") }
 
     belongs_to :artist
@@ -85,34 +81,27 @@ module MyApp
   end
 
   class AlbumReview < ActiveRecord::Base
-    attr_accessible :message
     belongs_to :album
   end
 
   class Song < ActiveRecord::Base
     default_scope -> { order(id: :asc) }
 
-    attr_accessible :title, :artist, :album
-
     belongs_to :artist
     belongs_to :album
   end
 
   class Payment < ActiveRecord::Base
-    attr_accessible :amount, :artist
-
     belongs_to :artist
     belongs_to :fan
   end
 
   class Fan < ActiveRecord::Base
-    attr_accessible :name
     has_many :payments
     has_many :artists, :through => :albums
   end
 
   class Stalker < ActiveRecord::Base
-    attr_accessible :name
     has_and_belongs_to_many :artists
   end
 end


### PR DESCRIPTION
When the first Active Record fixtures were added to the test suite in 0ba7f778447454275bc46e035358aeaf56e5e0e5, a call to `attr_accessible` was included in each model.

Later `protected_attributes` was added as a development dependency in c9403c5603a31a0799696258d95eeacda0814628 to allow the `attr_accessible` calls to continue to work on Rails 4.

Later still in b1a928c2dbcf000d29da055d299379d8822526aa, the dependency was switched to `protected_attributes_continued` as the original `protected_attributes` gem doesn't support Rails 5.

Now that Rails 5.2 has been released, the test suite is failing because `protected_attributes_continued` isn't compatible with it.

However, I don't think the `attr_accessible` calls were ever necessary: if I check out 0ba7f778447454275bc46e035358aeaf56e5e0e5 and remove them, the test suite still passes. restpack_serializer doesn't perform mass assignment on those models (or any assignment at all).