### PR TITLE
Avoid allocation when no associations are defined

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'coveralls', require: false
+gem 'memory_profiler', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,5 @@ RestPack::Gem::Tasks.load_tasks
 desc "Run some performance tests"
 task :perf do
   require_relative 'performance/perf.rb'
+  require_relative 'performance/mem.rb'
 end

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -144,9 +144,13 @@ module RestPack
       end
 
       def has_user_defined_method?(method_name)
-        user_defined_methods = self.user_defined_methods || []
-        return true if user_defined_methods.include?(method_name)
-        return self.superclass.try(:has_user_defined_method?, method_name)
+        if user_defined_methods && user_defined_methods.include?(method_name)
+          true
+        elsif superclass.respond_to?(:has_user_defined_method?)
+          superclass.has_user_defined_method?(method_name)
+        else
+          false
+        end
       end
 
       def memoized_has_user_defined_method?(method_name)

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -57,7 +57,7 @@ module RestPack
       end
 
       add_custom_attributes(data)
-      add_links(model, data) unless self.class.associations.empty?
+      add_links(model, data) if self.class.has_associations?
 
       data
     end

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -44,8 +44,12 @@ module RestPack::Serializer::SideLoading
       end
     end
 
+    def has_associations?
+      @can_includes
+    end
+
     def associations
-      return [] unless @can_includes
+      return [] unless has_associations?
       can_includes.map do |include|
         association = association_from_include(include)
         association if supported_association?(association.macro)

--- a/performance/mem.rb
+++ b/performance/mem.rb
@@ -1,0 +1,49 @@
+require 'memory_profiler'
+require_relative '../lib/restpack_serializer'
+
+class SimpleSerializer
+  include RestPack::Serializer
+  attributes :id, :title
+end
+
+simple_model = {
+  id: "123",
+  title: 'This is the title',
+}
+
+# warmup
+SimpleSerializer.as_json(simple_model)
+
+report = MemoryProfiler.report do
+  SimpleSerializer.as_json(simple_model)
+end
+
+puts "="*64
+puts "Simple Serializer:"
+puts "="*64
+
+report.pretty_print(detailed_report: false)
+
+class ComplexSerializer
+  include RestPack::Serializer
+
+  attributes :a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m, :n, :o, :p, :q, :r, :s, :t
+end
+
+complex_model = {
+  a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10,
+  k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20,
+}
+
+# warmup
+ComplexSerializer.as_json(complex_model)
+
+report = MemoryProfiler.report do
+  ComplexSerializer.as_json(complex_model)
+end
+
+puts "="*64
+puts "Complex Serializer:"
+puts "="*64
+
+report.pretty_print(detailed_report: false)


### PR DESCRIPTION
Previously an empty array would be allocated during serialisation when no associations are defined on the serialiser, which is quite common.

### Before:

    $ bundle exec ruby performance/mem.rb
    ================================================================
    Simple Serializer:
    ================================================================
    Total allocated: 544 bytes (4 objects)
    Total retained:  0 bytes (0 objects)

    ================================================================
    Complex Serializer:
    ================================================================
    Total allocated: 1240 bytes (4 objects)
    Total retained:  0 bytes (0 objects)

### After:

    $ bundle exec ruby performance/mem.rb
    ================================================================
    Simple Serializer:
    ================================================================
    Total allocated: 504 bytes (3 objects)
    Total retained:  0 bytes (0 objects)

    ================================================================
    Complex Serializer:
    ================================================================
    Total allocated: 1200 bytes (3 objects)
    Total retained:  0 bytes (0 objects)