### PR TITLE
Remove kaminari-mongoid dependency

### DIFF
--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', ['>= 4.0.3', '< 6.1']
   gem.add_dependency 'activerecord', ['>= 4.0.3', '< 6.1']
   gem.add_dependency 'kaminari', '~> 0.17.0'
-  gem.add_dependency 'kaminari-mongoid', '~> 0.1'
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
   gem.add_development_dependency 'rake', '~> 11.3'


### PR DESCRIPTION
This reverts commit b3117c113776ee81dfa9643f8db5d5242bbaefaa from https://github.com/RestPack/restpack_serializer/pull/140.

Using Kaminari 0.17.0 with Mongoid loaded causes a deprecation warning:

    DEPRECATION WARNING: Kaminari Mongoid support has been extracted to a separate gem, and will be removed in the next 1.0 release. Please bundle kaminari-mongoid gem.

This dependency was added to silence that warning in applications that use Mongoid, but those applications should add the dependency directly.

Eventually I'd like to relax the Kaminari dependency and allow 1.0 to be used, but before that we should publish a version that no longer depends on kaminari-mongoid, so that applications that currently rely on it via restpack_serializer can see the deprecation warning and bundle the gem.