### PR TITLE
Relax Kaminari dependency to allow 1.x versions

### DIFF
--- a/lib/restpack_serializer.rb
+++ b/lib/restpack_serializer.rb
@@ -6,7 +6,7 @@ require_relative 'restpack_serializer/serializable'
 require_relative 'restpack_serializer/factory'
 require_relative 'restpack_serializer/result'
 
-Kaminari::Hooks.init
+Kaminari::Hooks.init if defined?(Kaminari::Hooks)
 
 module RestPack
   module Serializer

--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', ['>= 4.0.3', '< 6.1']
   gem.add_dependency 'activerecord', ['>= 4.0.3', '< 6.1']
-  gem.add_dependency 'kaminari', '~> 0.17.0'
+  gem.add_dependency 'kaminari', ['>= 0.17.0', '< 2.0']
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
   gem.add_development_dependency 'rake', '~> 11.3'


### PR DESCRIPTION
Followup to https://github.com/RestPack/restpack_serializer/pull/147.

Kaminari 1.0 was released almost four years ago, but applications using this gem currently can't upgrade past 0.17.0.

There was only one change necessary for compatibility with 1.0: the `Kaminari::Hooks` constant no longer exists, as the adapter configuration it used to perform now happens automatically (e.g. [before](https://github.com/kaminari/kaminari/blob/v0.17.0/lib/kaminari/hooks.rb#L4-L7), [after](https://github.com/kaminari/kaminari/blob/v1.2.1/kaminari-activerecord/lib/kaminari/activerecord.rb#L6-L10)).