### PR TITLE
Switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        ruby-version:
+          - 2.1
+          - 2.2
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-rvm:
-  - 2.3.1
-script: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 
 gem 'coveralls', require: false
 gem 'memory_profiler', require: false
+
+if RUBY_VERSION < "2.2"
+  gem "sqlite3", "~> 1.3.0"
+end


### PR DESCRIPTION
Travis CI recently became significantly harder to use for open source projects:

https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Here I'm switching to GitHub Actions, and also adding a build matrix to test on every minor Ruby version.