### PR TITLE
Add camelization support

### DIFF
--- a/lib/restpack_serializer/version.rb
+++ b/lib/restpack_serializer/version.rb
@@ -1,5 +1,5 @@
 module RestPack
   module Serializer
-    VERSION = '0.6.14'
+    VERSION = '0.7.0'
   end
 end

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -222,6 +222,20 @@ describe RestPack::Serializer do
         )
       end
 
+      context "with camelize set to true on serializer" do
+        class CamelcaseSerializer < PersonSerializer
+          attributes :id, :name, :description, :href, :admin_info, :string_keys
+          camelize true
+          self.key = :people
+        end
+        let(:serializer) { CamelcaseSerializer }
+
+        it "converts the attribute names to lower camel case" do
+          hash = serializer.as_json(person, is_admin?: true, is_ben?: true)
+          expect(hash.keys).to eq([:id, :name, :description, :href, :adminInfo, :stringKeys, :customKey])
+        end
+      end
+
       it "excludes a blacklist of attributes if specified as an array" do
         expect(serializer.as_json(person, attribute_blacklist: [:name, :description])).to eq(
           id: '123',


### PR DESCRIPTION
This allows serialises to enable the use of camelCase keys in the output by adding `camelize true` to the serialiser class.

e.g. 

```
class PersonSerializer
   attributes :id, :name, :description, :href, :admin_info, :string_keys
   camelize true
end
```

Will output a JSON object with keys id, name, description, href, adminInfo and stringKeys.