### PR TITLE
Remove upper bound constraint on Rails

### DIFF
--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'activesupport', ['>= 4.0.3', '< 8.2']
-  gem.add_dependency 'activerecord', ['>= 4.0.3', '< 8.2']
+  gem.add_dependency 'activesupport', '>= 4.0.3'
+  gem.add_dependency 'activerecord', '>= 4.0.3'
   gem.add_dependency 'kaminari', ['>= 0.17.0', '< 2.0']
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'


### PR DESCRIPTION
All this does is prevent people from testing Rails edge and report issues early.

cc @eugeneius 